### PR TITLE
Add Play 3.0 cross-build alongside existing Play 2.9 support

### DIFF
--- a/.github/workflows/continouos-integration.yml
+++ b/.github/workflows/continouos-integration.yml
@@ -14,9 +14,15 @@ on:
 
 jobs:
   validate:
-    name: Validate Code
+    name: Validate Code (Play ${{ matrix.play }})
     if: "(github.event.release || github.event.release.prerelease) == false"
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        play: [ '2.9', '3.0' ]
+
     steps:
       - uses: actions/checkout@v4
 
@@ -30,26 +36,28 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Check Project Code
-        run: sbt validateCode
+        run: sbt -Dplay.version=${{ matrix.play }} validateCode
 
       - name: Upload ScalaStyle Report (XML)
+        if: matrix.play == '2.9'
         uses: actions/upload-artifact@v4
         with:
           name: scalastyle-reports
           path: ${{github.workspace}}/target/scalastyle-report/
 
   build:
-    name: Build
+    name: Build (Play ${{ matrix.play }} / Scala ${{ matrix.scala }})
     if: "(github.event.release || github.event.release.prerelease) == false"
     needs: [ validate ]
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        distribution: [ 'corretto' ]
-        jdk: [ '17' ]
-        scala: [ '2.13.18' ]
+        include:
+          - { play: '2.9', scala: '2.13.18', jdk: '17' }
+          - { play: '3.0', scala: '2.13.18', jdk: '17' }
+          - { play: '3.0', scala: '3.3.6',   jdk: '17' }
 
     steps:
       - name: Checkout repository
@@ -58,34 +66,29 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ matrix.distribution }}
+          distribution: corretto
           java-version: ${{ matrix.jdk }}
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
       - name: Perform Build / Test
-        run: sbt ++${{ matrix.scala }} compile test
+        run: sbt -Dplay.version=${{ matrix.play }} ++${{ matrix.scala }} compile test
 
   optional-build:
-    name: Build (Optional)
+    name: Build / Optional (Play ${{ matrix.play }} / Scala ${{ matrix.scala }} / JDK ${{ matrix.jdk }})
     if: "(github.event.release || github.event.release.prerelease) == false"
     continue-on-error: ${{ matrix.experimental }}
     needs: [ validate ]
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        distribution: [ 'corretto' ]
-        jdk: [ '17' ]
-        scala: [ '2.13.18' ]
-        experimental: [ false ]
         include:
-          - jdk: '21'
-            distribution: 'corretto'
-            scala: '2.13.18'
-            experimental: true
+          - { play: '2.9', scala: '2.13.18', jdk: '21', experimental: true }
+          - { play: '3.0', scala: '2.13.18', jdk: '21', experimental: true }
+          - { play: '3.0', scala: '3.3.6',   jdk: '21', experimental: true }
 
     steps:
       - name: Checkout repository
@@ -94,14 +97,14 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ matrix.distribution }}
+          distribution: corretto
           java-version: ${{ matrix.jdk }}
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
       - name: Perform Build / Test
-        run: sbt ++${{ matrix.scala }} compile test
+        run: sbt -Dplay.version=${{ matrix.play }} ++${{ matrix.scala }} compile test
 
   ready:
     name: Ready to Merge
@@ -111,9 +114,16 @@ jobs:
       - run: echo "Ready to merge!"
 
   publish:
-    name: Publish to Sonatype
+    name: Publish to Sonatype (Play ${{ matrix.play }})
     if: "github.event.release || github.event.release.prerelease"
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        play: [ '2.9', '3.0' ]
+
     steps:
       - uses: actions/checkout@v4
 
@@ -127,7 +137,7 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Publish package
-        run: sbt ci-release
+        run: sbt -Dplay.version=${{ matrix.play }} ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ suffix that matches the Play major your application is on (see
 [Cross-building](#cross-building) below).
 
 ```sbt
-  // Play 2.9
-  libraryDependencies += "io.github.felipebonezi" %% "play-actuator_play29" % "(version)"
+  // Play 2.9 (existing, unsuffixed coordinates - no migration needed)
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator" % "(version)"
 
-  // Play 3.0
+  // Play 3.0 (new)
   libraryDependencies += "io.github.felipebonezi" %% "play-actuator_play30" % "(version)"
 ```
 
@@ -68,7 +68,7 @@ It depends on which dependency indicator you'll use.
 #### JDBC
 ```sbt
   // Play 2.9
-  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-jdbc-indicator_play29" % "(version)"
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-jdbc-indicator" % "(version)"
   // Play 3.0
   libraryDependencies += "io.github.felipebonezi" %% "play-actuator-jdbc-indicator_play30" % "(version)"
 ```
@@ -76,7 +76,7 @@ It depends on which dependency indicator you'll use.
 #### Slick
 ```sbt
   // Play 2.9
-  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-slick-indicator_play29" % "(version)"
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-slick-indicator" % "(version)"
   // Play 3.0
   libraryDependencies += "io.github.felipebonezi" %% "play-actuator-slick-indicator_play30" % "(version)"
 ```
@@ -90,7 +90,7 @@ Show to you information about your Redis connection.
 
 ```sbt
   // Play 2.9
-  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-redis-indicator_play29" % "(version)"
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-redis-indicator" % "(version)"
   // Play 3.0
   libraryDependencies += "io.github.felipebonezi" %% "play-actuator-redis-indicator_play30" % "(version)"
 ```
@@ -107,10 +107,15 @@ inside the JSON return by `/actuator/info` route. Default is disabled.
 `play-actuator` is published for two Play majors. Pick the coordinate
 suffix that matches the Play version your application is on:
 
-| Your Play | Coordinate suffix | Scala         |
-|-----------|-------------------|---------------|
-| 2.9.x     | `_play29`         | 2.13          |
-| 3.0.x     | `_play30`         | 2.13 or 3.3   |
+| Your Play | Coordinate suffix     | Scala         |
+|-----------|-----------------------|---------------|
+| 2.9.x     | *(none, unsuffixed)*  | 2.13          |
+| 3.0.x     | `_play30`             | 2.13 or 3.3   |
+
+The Play 2.9 axis continues to publish under the original, unsuffixed
+coordinates — existing consumers do **not** need to update their
+`libraryDependencies` strings when they pick up a new release. Only the
+new Play 3.0 axis introduces a coordinate suffix.
 
 For local development, switch axes with the `play.version` JVM property
 (or the equivalent `PLAY_VERSION` env var). The default is Play 2.9:

--- a/README.md
+++ b/README.md
@@ -14,10 +14,16 @@ This project is inspired by `Spring Boot Actuator` architecture
 ## How to use?
 [![Version](https://img.shields.io/github/v/release/felipebonezi/play-actuator?logo=java)](https://github.com/felipebonezi/play-actuator/releases)
 
-You can import as a project dependency in your `build.sbt` file.
+You can import as a project dependency in your `build.sbt` file. Pick the
+suffix that matches the Play major your application is on (see
+[Cross-building](#cross-building) below).
 
 ```sbt
-  libraryDependencies ++= "io.github.felipebonezi" %% "play-actuator" % "(version)"
+  // Play 2.9
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator_play29" % "(version)"
+
+  // Play 3.0
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator_play30" % "(version)"
 ```
 
 After that, you need to configure `play.actuator.ActuatorRouter` into project `conf/routes` file.
@@ -61,12 +67,18 @@ It depends on which dependency indicator you'll use.
 
 #### JDBC
 ```sbt
-  libraryDependencies ++= "io.github.felipebonezi" %% "play-actuator-jdbc-indicator" % "(version)"
+  // Play 2.9
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-jdbc-indicator_play29" % "(version)"
+  // Play 3.0
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-jdbc-indicator_play30" % "(version)"
 ```
 
 #### Slick
 ```sbt
-  libraryDependencies ++= "io.github.felipebonezi" %% "play-actuator-slick-indicator" % "(version)"
+  // Play 2.9
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-slick-indicator_play29" % "(version)"
+  // Play 3.0
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-slick-indicator_play30" % "(version)"
 ```
 
 ### Redis Indicator
@@ -77,7 +89,10 @@ Show to you information about your Redis connection.
 `play.actuator.health.indicators.redis = true`
 
 ```sbt
-  libraryDependencies ++= "io.github.felipebonezi" %% "play-actuator-redis-indicator" % "(version)"
+  // Play 2.9
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-redis-indicator_play29" % "(version)"
+  // Play 3.0
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-redis-indicator_play30" % "(version)"
 ```
 
 ## Info endpoint details
@@ -87,10 +102,29 @@ inside the JSON return by `/actuator/info` route. Default is disabled.
 
 `play.actuator.info.system.enabled = true`
 
+## Cross-building
+
+`play-actuator` is published for two Play majors. Pick the coordinate
+suffix that matches the Play version your application is on:
+
+| Your Play | Coordinate suffix | Scala         |
+|-----------|-------------------|---------------|
+| 2.9.x     | `_play29`         | 2.13          |
+| 3.0.x     | `_play30`         | 2.13 or 3.3   |
+
+For local development, switch axes with the `play.version` JVM property
+(or the equivalent `PLAY_VERSION` env var). The default is Play 2.9:
+
+```bash
+sbt -Dplay.version=2.9 ++2.13.18 compile test    # Play 2.9 / Scala 2.13
+sbt -Dplay.version=3.0 ++2.13.18 compile test    # Play 3.0 / Scala 2.13
+sbt -Dplay.version=3.0 ++3.3.6   compile test    # Play 3.0 / Scala 3
+```
+
 ## Scala compatibility
 
-This project is compatible with Scala `2.12` and `2.13`, so you need to use the right version.
-Be aware that we're considering to drop `2.12` compatibility, so, we advise you to use `2.13` as your preferred version.
+This project is published for Scala `2.13` on both Play axes, plus Scala
+`3.3` (LTS) on the Play 3.0 axis.
 
 ## Sponsors & Backers
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,10 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import Common._
-import Dependencies.scala213
+import PlayCrossBuilding.artifactSuffix
+import PlayCrossBuilding.crossScala
+import PlayCrossBuilding.defaultScalaVersion
+import PlayCrossBuilding.isPlay30
 
 lazy val root = project
   .in(file("."))
@@ -33,10 +36,10 @@ lazy val root = project
 lazy val core = project
   .in(file("play-actuator-core"))
   .settings(
-    name                               := s"$repoName-core",
+    name                               := s"$repoName-core$artifactSuffix",
     organization                       := "io.github.felipebonezi",
-    scalaVersion                       := scala213,
-    crossScalaVersions                 := Seq(scala213),
+    scalaVersion                       := defaultScalaVersion,
+    crossScalaVersions                 := crossScala,
     versionScheme                      := Some("early-semver"),
     ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org",
     ThisBuild / sonatypeRepository     := "https://s01.oss.sonatype.org/service/local",
@@ -54,10 +57,10 @@ lazy val actuator = project
   .dependsOn(core)
   .enablePlugins(Common, BuildInfoPlugin)
   .settings(
-    name                               := s"$repoName",
+    name                               := s"$repoName$artifactSuffix",
     organization                       := "io.github.felipebonezi",
-    scalaVersion                       := scala213,
-    crossScalaVersions                 := Seq(scala213),
+    scalaVersion                       := defaultScalaVersion,
+    crossScalaVersions                 := crossScala,
     versionScheme                      := Some("early-semver"),
     ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org",
     ThisBuild / sonatypeRepository     := "https://s01.oss.sonatype.org/service/local",
@@ -77,10 +80,10 @@ lazy val jdbc = project
   .in(file("play-actuator-indicators/database/jdbc"))
   .dependsOn(core)
   .settings(
-    name                               := s"$jdbcIndicatorName",
+    name                               := s"$jdbcIndicatorName$artifactSuffix",
     organization                       := "io.github.felipebonezi",
-    scalaVersion                       := scala213,
-    crossScalaVersions                 := Seq(scala213),
+    scalaVersion                       := defaultScalaVersion,
+    crossScalaVersions                 := crossScala,
     versionScheme                      := Some("early-semver"),
     ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org",
     ThisBuild / sonatypeRepository     := "https://s01.oss.sonatype.org/service/local",
@@ -98,10 +101,10 @@ lazy val slick = project
   .in(file("play-actuator-indicators/database/slick"))
   .dependsOn(core)
   .settings(
-    name                               := s"$slickIndicatorName",
+    name                               := s"$slickIndicatorName$artifactSuffix",
     organization                       := "io.github.felipebonezi",
-    scalaVersion                       := scala213,
-    crossScalaVersions                 := Seq(scala213),
+    scalaVersion                       := defaultScalaVersion,
+    crossScalaVersions                 := crossScala,
     versionScheme                      := Some("early-semver"),
     ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org",
     ThisBuild / sonatypeRepository     := "https://s01.oss.sonatype.org/service/local",
@@ -119,10 +122,10 @@ lazy val redis = project
   .in(file("play-actuator-indicators/database/redis"))
   .dependsOn(core)
   .settings(
-    name                               := s"$redisIndicatorName",
+    name                               := s"$redisIndicatorName$artifactSuffix",
     organization                       := "io.github.felipebonezi",
-    scalaVersion                       := scala213,
-    crossScalaVersions                 := Seq(scala213),
+    scalaVersion                       := defaultScalaVersion,
+    crossScalaVersions                 := crossScala,
     versionScheme                      := Some("early-semver"),
     ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org",
     ThisBuild / sonatypeRepository     := "https://s01.oss.sonatype.org/service/local",
@@ -136,14 +139,26 @@ lazy val redis = project
   )
   .enablePlugins(Common)
 
+// scalastyle 1.0.0 cannot parse Scala 3, so it's gated to the Play 2.9 (Scala
+// 2.13-only) axis. Scala 3 sources are still covered by scalafmt + compiler.
 addCommandAlias(
   "validateCode",
-  List(
-    "headerCheckAll",
-    "scalafmtSbtCheck",
-    "scalafmtCheckAll",
-    "test:scalafmtCheckAll",
-    "scalastyle",
-    "test:scalastyle",
+  (
+    if (isPlay30)
+      List(
+        "headerCheckAll",
+        "scalafmtSbtCheck",
+        "scalafmtCheckAll",
+        "test:scalafmtCheckAll",
+      )
+    else
+      List(
+        "headerCheckAll",
+        "scalafmtSbtCheck",
+        "scalafmtCheckAll",
+        "test:scalafmtCheckAll",
+        "scalastyle",
+        "test:scalastyle",
+      )
   ).mkString(";")
 )

--- a/play-actuator-core/src/main/scala/play/actuator/ActuatorEnum.scala
+++ b/play-actuator-core/src/main/scala/play/actuator/ActuatorEnum.scala
@@ -20,8 +20,16 @@
  */
 package play.actuator
 
+import play.api.libs.json.JsString
+import play.api.libs.json.Writes
+
 object ActuatorEnum extends Enumeration {
   type Status = Value
 
   val Up, Down = Value
+
+  // Play JSON 2.x synthesises a Writes for Enumeration#Value automatically on
+  // Scala 2.13, but Scala 3 does not pick that path up; expose an explicit
+  // Writes via the companion so the same source compiles on both axes.
+  implicit val statusWrites: Writes[Status] = (s: Status) => JsString(s.toString)
 }

--- a/play-actuator-sample/build.sbt
+++ b/play-actuator-sample/build.sbt
@@ -31,13 +31,13 @@ resolvers ++= DefaultOptions.resolvers(snapshot = true)
 libraryDependencies += javaJdbc
 libraryDependencies += cacheApi
 libraryDependencies += guice
-libraryDependencies += "org.postgresql"         % "postgresql" % "42.7.2"
-libraryDependencies += "com.github.karelcemus" %% "play-redis" % "3.0.0"
+libraryDependencies += "org.postgresql"         % "postgresql" % "42.7.4"
+libraryDependencies += "com.github.karelcemus" %% "play-redis" % "5.4.0"
 
-lazy val actuatorVersion = "0.2.0+8-0577a9db+20221209-1830-SNAPSHOT"
-libraryDependencies += "io.github.felipebonezi" %% "play-actuator"                 % actuatorVersion
-libraryDependencies += "io.github.felipebonezi" %% "play-actuator-redis-indicator" % actuatorVersion
-libraryDependencies += "io.github.felipebonezi" %% "play-actuator-jdbc-indicator"  % actuatorVersion
+lazy val actuatorVersion = "0.0.0+50-9882b9cc+20260521-0238-SNAPSHOT"
+libraryDependencies += "io.github.felipebonezi" %% "play-actuator_play30"                 % actuatorVersion
+libraryDependencies += "io.github.felipebonezi" %% "play-actuator-redis-indicator_play30" % actuatorVersion
+libraryDependencies += "io.github.felipebonezi" %% "play-actuator-jdbc-indicator_play30"  % actuatorVersion
 
 libraryDependencies += specs2                    % Test
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test

--- a/play-actuator-sample/project/build.properties
+++ b/play-actuator-sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.2
+sbt.version = 1.10.7

--- a/play-actuator-sample/project/plugins.sbt
+++ b/play-actuator-sample/project/plugins.sbt
@@ -18,4 +18,4 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.1")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.10")

--- a/play-actuator/src/main/scala/play/actuator/info/InfoService.scala
+++ b/play-actuator/src/main/scala/play/actuator/info/InfoService.scala
@@ -45,7 +45,7 @@ class InfoService @Inject() (config: Configuration) {
       import scala.collection.immutable.ListMap
 
       val systemInfos       = System.getProperties.asScala.map(p => (p._1, JsString(p._2)))
-      val sortedSystemInfos = ListMap(systemInfos.toSeq.sortBy(_._1): _*)
+      val sortedSystemInfos = ListMap.from(systemInfos.toSeq.sortBy(_._1))
       buildInfos = buildInfos + ("system" -> JsObject(sortedSystemInfos))
     }
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -18,7 +18,7 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import Dependencies.scala213
+import PlayCrossBuilding.defaultScalaVersion
 import de.heikoseeberger.sbtheader.HeaderPlugin
 import sbt.Keys._
 import sbt._
@@ -46,7 +46,7 @@ object Common extends AutoPlugin {
       organizationName     := "Felipe Bonezi",
       organizationHomepage := Some(url("https://about.me/felipebonezi")),
       // scala settings
-      scalaVersion := scala213,
+      scalaVersion := defaultScalaVersion,
       scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-encoding", "utf8"),
       javacOptions ++= Seq("-encoding", "UTF-8"),
       // legal

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,8 +48,11 @@ object PlayCrossBuilding {
   val playRedisVersion: String      = if (isPlay30) "5.4.0" else "3.0.0"
   val typesafeConfigVersion: String = "1.4.3"
 
-  // Suffix lets the two axes coexist in Maven Central without colliding.
-  val artifactSuffix: String = if (isPlay30) "_play30" else "_play29"
+  // Suffix lets the Play 3.0 axis coexist with the existing unsuffixed
+  // Play 2.9 artifacts on Maven Central — keeping the 2.9 coordinates
+  // unchanged means consumers already on Play 2.9 don't need to touch
+  // their build.sbt.
+  val artifactSuffix: String = if (isPlay30) "_play30" else ""
 }
 
 object Dependencies {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,36 +21,66 @@
 import sbt.Keys.libraryDependencies
 import sbt._
 
-object Dependencies {
+// Single source of truth for the Play / Scala / ecosystem-library axis selected
+// at sbt boot time. Pick the Play 3.0 axis with `-Dplay.version=3.0` or
+// `PLAY_VERSION=3.0` in the env. Default stays on Play 2.9.
+object PlayCrossBuilding {
+  val DefaultPlayVersion = "2.9"
 
-  val scala213 = "2.13.18"
+  val playMajor: String = sys.props
+    .getOrElse("play.version", sys.env.getOrElse("PLAY_VERSION", DefaultPlayVersion))
+    .trim
 
-  val playVersion: String           = "2.9.10"
-  val playSlickVersion: String      = "5.3.0"
-  val playJsonVersion: String       = "2.10.6"
-  val playRedisVersion: String      = "3.0.0"
+  val isPlay30: Boolean = playMajor.startsWith("3.")
+  val isPlay29: Boolean = playMajor.startsWith("2.9")
+  require(isPlay29 || isPlay30, s"Unsupported play.version=$playMajor (expected 2.9 or 3.0)")
+
+  val Scala213: String            = "2.13.18"
+  val Scala3: String              = "3.3.6"
+  val crossScala: Seq[String]     = if (isPlay30) Seq(Scala213, Scala3) else Seq(Scala213)
+  val defaultScalaVersion: String = Scala213
+
+  val playGroup: String             = if (isPlay30) "org.playframework" else "com.typesafe.play"
+  val playRedisGroup: String        = "com.github.karelcemus"
+  val playVersion: String           = if (isPlay30) "3.0.10" else "2.9.10"
+  val playJsonVersion: String       = if (isPlay30) "3.0.6" else "2.10.6"
+  val playSlickVersion: String      = if (isPlay30) "6.2.0" else "5.3.0"
+  val playRedisVersion: String      = if (isPlay30) "5.4.0" else "3.0.0"
   val typesafeConfigVersion: String = "1.4.3"
 
+  // Suffix lets the two axes coexist in Maven Central without colliding.
+  val artifactSuffix: String = if (isPlay30) "_play30" else "_play29"
+}
+
+object Dependencies {
+
+  import PlayCrossBuilding._
+
+  // Back-compat aliases preserved so the existing build.sbt structure
+  // and any external references still resolve.
+  val scala213: String           = Scala213
+  val crossScalaSeq: Seq[String] = crossScala
+
   val core: Seq[ModuleID] = Seq(
-    "com.typesafe.play" %% "play-guice" % playVersion,
-    "com.typesafe.play" %% "play-test"  % playVersion % Test,
-    "com.typesafe"       % "config"     % typesafeConfigVersion
+    playGroup     %% "play-guice" % playVersion,
+    playGroup     %% "play-test"  % playVersion % Test,
+    "com.typesafe" % "config"     % typesafeConfigVersion
   )
 
   val actuator = libraryDependencies ++= core ++ Seq(
-    "com.typesafe.play" %% "play-json" % playJsonVersion
+    playGroup %% "play-json" % playJsonVersion
   )
 
   val jdbc = libraryDependencies ++= core ++ Seq(
-    "com.typesafe.play" %% "play-jdbc" % playVersion
+    playGroup %% "play-jdbc" % playVersion
   )
 
   val slick = libraryDependencies ++= core ++ Seq(
-    "com.typesafe.play" %% "play-slick" % playSlickVersion
+    playGroup %% "play-slick" % playSlickVersion
   )
 
   val redis = libraryDependencies ++= core ++ Seq(
-    "com.github.karelcemus" %% "play-redis" % playRedisVersion
+    playRedisGroup %% "play-redis" % playRedisVersion
   )
 
 }


### PR DESCRIPTION
Switching axes is driven by `-Dplay.version=2.9|3.0` (env: `PLAY_VERSION`).
Default stays on Play 2.9 so existing consumers are unaffected. The Play
3.0 axis additionally cross-builds for Scala 3.3 (LTS) on top of Scala
2.13. Artifact IDs are suffixed with `_play29` / `_play30` so the two
families coexist on Maven Central.

- Introduce `PlayCrossBuilding` helper in `project/Dependencies.scala`
  with the version table for both axes (Play core, play-json, play-slick,
  play-jdbc, play-guice, play-test, karelcemus/play-redis).
- Wire `build.sbt` and `project/Common.scala` through the helper for
  `scalaVersion`, `crossScalaVersions`, and the artifact-name suffix.
  Gate scalastyle to the Scala 2.13-only Play 2.9 axis (scalastyle 1.0.0
  cannot parse Scala 3 sources).
- Source-level Scala 3 fixes: rewrite `ListMap(...: _*)` to
  `ListMap.from(...)` in `InfoService`, and add an explicit
  `Writes[Status]` in `ActuatorEnum`'s companion so Play JSON
  serialization works without the Scala 2.13 enumeration-Writes
  synthesis path.
- CI matrix fans out to {Play 2.9 / Scala 2.13}, {Play 3.0 / Scala 2.13},
  {Play 3.0 / Scala 3.3}. Release publishing runs `ci-release` once per
  Play axis (serialized to avoid Sonatype staging races).
- Upgrade the sample app to Play 3.0: sbt-plugin `org.playframework`
  3.0.10, sbt 1.10.7, play-redis 5.4.0, and the new `_play30` artifact
  coordinates.
- README cross-building section and updated dependency snippets.