### PR TITLE
Add health groups + 503-on-Down for Kubernetes liveness/readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,21 @@ Run your project and check Actuators endpoints - e.g. `/actuator/health`.
 
 Below we have all project endpoints available on this project.
 
-| Endpoint ID | Description                                  | Path                | Ready to use? |
-|-------------|----------------------------------------------|---------------------|---------------|
-| health      | Displays your application’s health status.   | `/actuator/health`  | ✔️            |
-| info        | Displays information about your application. | `/actuator/info`    | ✔️            |
-| logfile     | Returns the contents of the log file.        | `/actuator/logfile` | ✖️            |
+| Endpoint ID         | Description                                            | Path                            | Ready to use? |
+|---------------------|--------------------------------------------------------|---------------------------------|---------------|
+| health              | Aggregated health (all active indicators).             | `/actuator/health`              | ✔️            |
+| health (liveness)   | Kubernetes liveness probe (default: `diskSpace` only). | `/actuator/health/liveness`     | ✔️            |
+| health (readiness)  | Kubernetes readiness probe (default: external deps).   | `/actuator/health/readiness`    | ✔️            |
+| health (group)      | Any user-defined group from `play.actuator.health.groups`. | `/actuator/health/<group>` | ✔️            |
+| info                | Displays information about your application.           | `/actuator/info`                | ✔️            |
+| metrics             | List/inspect Micrometer meters (opt-in module).        | `/actuator/metrics`             | ✔️            |
+| prometheus          | Prometheus exposition (opt-in module).                 | `/actuator/metrics/prometheus`  | ✔️            |
+| logfile             | Returns the contents of the log file.                  | `/actuator/logfile`             | ✖️            |
+
+Health endpoints return **HTTP 200** when the aggregated status is `UP`
+and **HTTP 503** when any included indicator is `DOWN` — so Kubernetes
+liveness and readiness probes work out of the box. Unknown group names
+return **HTTP 404**.
 
 ## Health endpoint details
 
@@ -94,6 +104,67 @@ Show to you information about your Redis connection.
   // Play 3.0
   libraryDependencies += "io.github.felipebonezi" %% "play-actuator-redis-indicator_play30" % "(version)"
 ```
+
+### Health groups (liveness / readiness)
+
+`play-actuator` ships with two opinionated default groups so Kubernetes
+probes work without any extra configuration:
+
+| Group        | Default indicators       | Suitable for       |
+|--------------|--------------------------|--------------------|
+| `liveness`   | `diskSpace` only         | `livenessProbe`    |
+| `readiness`  | everything except `diskSpace` | `readinessProbe` |
+
+Both can be overridden in `application.conf`. You can also define
+arbitrary custom groups (each becomes a new `/actuator/health/<name>`
+endpoint):
+
+```hocon
+play.actuator.health.groups {
+  liveness  { include = ["diskSpace"] }
+  readiness { exclude = ["diskSpace"] }
+
+  # any user-defined group
+  storage   { include = ["database"]  }
+}
+```
+
+`include` is a whitelist (empty means "all indicators"). `exclude`
+always subtracts from the include set.
+
+## Metrics endpoint details
+
+Add the optional metrics module to expose Micrometer-based JVM metrics
+and a Prometheus scrape endpoint.
+
+```sbt
+  // Play 2.9
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-metrics" % "(version)"
+  // Play 3.0
+  libraryDependencies += "io.github.felipebonezi" %% "play-actuator-metrics_play30" % "(version)"
+```
+
+Then mount the metrics sub-router in `conf/routes` alongside the main
+actuator router:
+
+```
+->   /actuator           play.actuator.ActuatorRouter
+->   /actuator/metrics   play.actuator.metrics.MetricsRouter
+```
+
+This exposes:
+
+| Method + path                   | Returns                                      |
+|---------------------------------|----------------------------------------------|
+| `GET /actuator/metrics`         | JSON list of meter names                     |
+| `GET /actuator/metrics/<name>`  | JSON detail (measurements + available tags)  |
+| `GET /actuator/metrics/prometheus` | `text/plain` Prometheus exposition format |
+
+JVM and system meter binders (memory, GC, threads, classloader,
+processor, uptime, file descriptors) are registered eagerly at startup
+and can be turned off individually under
+`play.actuator.metrics.bindings.*`. Apply common tags to every meter
+(e.g. application/env) via `play.actuator.metrics.common-tags { … }`.
 
 ## Info endpoint details
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ import PlayCrossBuilding.isPlay30
 
 lazy val root = project
   .in(file("."))
-  .aggregate(core, actuator, jdbc, slick, redis)
+  .aggregate(core, actuator, jdbc, slick, redis, metrics)
   .settings(
     name               := "play-actuator-root",
     crossScalaVersions := Nil,
@@ -136,6 +136,27 @@ lazy val redis = project
       )
     ),
     Dependencies.redis
+  )
+  .enablePlugins(Common)
+
+lazy val metrics = project
+  .in(file("play-actuator-indicators/metrics"))
+  .dependsOn(core)
+  .settings(
+    name                               := s"$metricsName$artifactSuffix",
+    organization                       := "io.github.felipebonezi",
+    scalaVersion                       := defaultScalaVersion,
+    crossScalaVersions                 := crossScala,
+    versionScheme                      := Some("early-semver"),
+    ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org",
+    ThisBuild / sonatypeRepository     := "https://s01.oss.sonatype.org/service/local",
+    scmInfo := Some(
+      ScmInfo(
+        url(s"https://github.com/felipebonezi/$repoName/play-actuator-indicators/metrics"),
+        s"scm:git:git@github.com:felipebonezi/$repoName.git"
+      )
+    ),
+    Dependencies.metrics
   )
   .enablePlugins(Common)
 

--- a/play-actuator-core/src/main/scala/play/actuator/health/HealthGroup.scala
+++ b/play-actuator-core/src/main/scala/play/actuator/health/HealthGroup.scala
@@ -18,18 +18,17 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package play.actuator
+package play.actuator.health
 
-import javax.inject.Inject
-
-import play.api.routing.Router.Routes
-import play.api.routing.SimpleRouter
-import play.api.routing.sird._
-
-class ActuatorRouter @Inject() (controller: ActuatorController) extends SimpleRouter {
-  override def routes: Routes = {
-    case GET(p"/health")        => controller.health
-    case GET(p"/health/$group") => controller.healthGroup(group)
-    case GET(p"/info")          => controller.info
+// `include` empty means "all indicators". `exclude` always subtracts.
+final case class HealthGroup(
+    name: String,
+    include: Set[String] = Set.empty,
+    exclude: Set[String] = Set.empty
+) {
+  def matches(indicatorName: String): Boolean = {
+    val included = include.isEmpty || include.contains(indicatorName)
+    val excluded = exclude.contains(indicatorName)
+    included && !excluded
   }
 }

--- a/play-actuator-core/src/main/scala/play/actuator/health/HealthGroupsConfig.scala
+++ b/play-actuator-core/src/main/scala/play/actuator/health/HealthGroupsConfig.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 Felipe Bonezi <https://about.me/felipebonezi>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package play.actuator.health
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+import scala.jdk.CollectionConverters._
+
+import com.typesafe.config.ConfigObject
+import play.api.Configuration
+
+@Singleton
+class HealthGroupsConfig @Inject() (config: Configuration) {
+
+  // Parse `play.actuator.health.groups.<name>.{include,exclude}` into a Map.
+  // Defaults (liveness/readiness) ship via reference.conf so consumers get
+  // Kubernetes-ready probe endpoints with zero application.conf changes.
+  val groups: Map[String, HealthGroup] = {
+    val key = "play.actuator.health.groups"
+    if (!config.has(key)) Map.empty
+    else {
+      val obj = config.underlying.getObject(key)
+      obj.entrySet().asScala.iterator.map { e =>
+        val name = e.getKey
+        val gc   = e.getValue.asInstanceOf[ConfigObject].toConfig
+        val include =
+          if (gc.hasPath("include")) gc.getStringList("include").asScala.toSet else Set.empty[String]
+        val exclude =
+          if (gc.hasPath("exclude")) gc.getStringList("exclude").asScala.toSet else Set.empty[String]
+        name -> HealthGroup(name, include, exclude)
+      }.toMap
+    }
+  }
+
+  def get(name: String): Option[HealthGroup] = groups.get(name)
+}

--- a/play-actuator-indicators/metrics/src/main/resources/reference.conf
+++ b/play-actuator-indicators/metrics/src/main/resources/reference.conf
@@ -1,0 +1,29 @@
+play {
+  actuator {
+    metrics {
+      enabled = true
+
+      # Tags applied to every meter produced by this app. Spring parity for
+      # cross-service Prometheus dashboards (e.g. application, env, region).
+      common-tags { }
+
+      # Default JVM-level binders. Set any of these to false to drop the
+      # corresponding meters from the registry at startup.
+      bindings {
+        jvm-memory       = true
+        jvm-gc           = true
+        jvm-threads      = true
+        classloader      = true
+        processor        = true
+        uptime           = true
+        file-descriptors = true
+      }
+
+      prometheus {
+        enabled = true
+      }
+    }
+  }
+}
+
+play.modules.enabled += "play.actuator.metrics.MetricsModule"

--- a/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MeterBindersInitializer.scala
+++ b/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MeterBindersInitializer.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 Felipe Bonezi <https://about.me/felipebonezi>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package play.actuator.metrics
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.binder.MeterBinder
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics
+import io.micrometer.core.instrument.binder.system.UptimeMetrics
+import play.api.Configuration
+
+// Eagerly registers the configured JVM/system MeterBinders against the
+// MeterRegistry at app boot. Each binder is gated on a config flag so
+// applications can drop expensive groups (e.g. JvmGcMetrics on hot paths).
+@Singleton
+class MeterBindersInitializer @Inject() (registry: MeterRegistry, config: Configuration) {
+
+  private def maybe(key: String, mk: => MeterBinder): Option[MeterBinder] =
+    if (enabled(key)) Some(mk) else None
+
+  private def enabled(key: String): Boolean =
+    config.getOptional[Boolean](s"play.actuator.metrics.bindings.$key").getOrElse(true)
+
+  private val binders: Seq[MeterBinder] = Seq(
+    maybe("jvm-memory", new JvmMemoryMetrics),
+    maybe("jvm-gc", new JvmGcMetrics),
+    maybe("jvm-threads", new JvmThreadMetrics),
+    maybe("classloader", new ClassLoaderMetrics),
+    maybe("processor", new ProcessorMetrics),
+    maybe("uptime", new UptimeMetrics),
+    maybe("file-descriptors", new FileDescriptorMetrics)
+  ).flatten
+
+  binders.foreach(_.bindTo(registry))
+}

--- a/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MeterRegistryProvider.scala
+++ b/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MeterRegistryProvider.scala
@@ -18,43 +18,39 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package play.actuator.health
+package play.actuator.metrics
 
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 import scala.jdk.CollectionConverters._
 
-import com.typesafe.config.ConfigObject
+import io.micrometer.core.instrument.Tag
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import play.api.Configuration
 
 @Singleton
-class HealthGroupsConfig @Inject() (config: Configuration) {
-
-  // Parse `play.actuator.health.groups.<name>.{include,exclude}` into a Map.
-  // Defaults (liveness/readiness) ship via reference.conf so consumers get
-  // Kubernetes-ready probe endpoints with zero application.conf changes.
-  val groups: Map[String, HealthGroup] = {
-    val key = "play.actuator.health.groups"
-    if (!config.has(key)) Map.empty
-    else {
-      val obj = config.underlying.getObject(key)
-      obj
-        .entrySet()
-        .asScala
-        .iterator
-        .map { e =>
-          val name = e.getKey
-          val gc   = e.getValue.asInstanceOf[ConfigObject].toConfig
-          val include =
-            if (gc.hasPath("include")) gc.getStringList("include").asScala.toSet else Set.empty[String]
-          val exclude =
-            if (gc.hasPath("exclude")) gc.getStringList("exclude").asScala.toSet else Set.empty[String]
-          name -> HealthGroup(name, include, exclude)
-        }
-        .toMap
+class MeterRegistryProvider @Inject() (config: Configuration)
+    extends Provider[PrometheusMeterRegistry] {
+  override def get(): PrometheusMeterRegistry = {
+    val registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+    val tags     = commonTags(config)
+    if (tags.nonEmpty) {
+      registry.config().commonTags(tags.asJava)
     }
+    registry
   }
 
-  def get(name: String): Option[HealthGroup] = groups.get(name)
+  private def commonTags(c: Configuration): Seq[Tag] = {
+    val key = "play.actuator.metrics.common-tags"
+    if (!c.has(key)) {
+      Seq.empty
+    } else {
+      c.underlying.getObject(key).entrySet().asScala.iterator.map { e =>
+        Tag.of(e.getKey, e.getValue.unwrapped().toString)
+      }.toSeq
+    }
+  }
 }

--- a/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MetricsController.scala
+++ b/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MetricsController.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022 Felipe Bonezi <https://about.me/felipebonezi>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package play.actuator.metrics
+
+import javax.inject.Inject
+
+import scala.jdk.CollectionConverters._
+
+import io.micrometer.core.instrument.Meter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import play.api.libs.json.JsObject
+import play.api.libs.json.JsString
+import play.api.libs.json.Json
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.BaseController
+import play.api.mvc.ControllerComponents
+
+class MetricsController @Inject() (
+    registry: MeterRegistry,
+    prometheusRegistry: PrometheusMeterRegistry,
+    cc: ControllerComponents
+) extends BaseController {
+
+  // GET /metrics — Spring-compatible: { "names": [...] }
+  def list: Action[AnyContent] = Action {
+    val names = registry.getMeters.asScala.iterator.map(_.getId.getName).toSet.toSeq.sorted
+    Ok(Json.obj("names" -> names))
+  }
+
+  // GET /metrics/:name — Spring-compatible meter detail JSON.
+  def detail(name: String): Action[AnyContent] = Action {
+    val meters = registry.getMeters.asScala.filter(_.getId.getName == name).toSeq
+    if (meters.isEmpty) {
+      NotFound(Json.obj("error" -> s"meter not found: $name"))
+    } else {
+      Ok(meterToJson(name, meters))
+    }
+  }
+
+  // GET /metrics/prometheus — text/plain Prometheus exposition.
+  def prometheus: Action[AnyContent] = Action {
+    val body = prometheusRegistry.scrape()
+    Ok(body).as("text/plain; version=0.0.4; charset=utf-8")
+  }
+
+  protected override def controllerComponents: ControllerComponents = this.cc
+
+  private def meterToJson(name: String, meters: Seq[Meter]): JsObject = {
+    val measurements = meters.flatMap { m =>
+      m.measure().asScala.map { ms =>
+        Json.obj(
+          "statistic" -> ms.getStatistic.toString,
+          "value"     -> ms.getValue
+        )
+      }
+    }
+    val tags = meters
+      .flatMap(_.getId.getTags.asScala)
+      .groupBy(_.getKey)
+      .map { case (k, vs) => Json.obj("tag" -> k, "values" -> vs.map(_.getValue).distinct) }
+      .toSeq
+    val baseUnit = Option(meters.head.getId.getBaseUnit).map(JsString.apply)
+    val base = Json.obj(
+      "name"            -> name,
+      "measurements"    -> measurements,
+      "availableTags"   -> tags
+    )
+    baseUnit.fold(base)(u => base + ("baseUnit" -> u))
+  }
+
+}

--- a/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MetricsModule.scala
+++ b/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MetricsModule.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Felipe Bonezi <https://about.me/felipebonezi>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package play.actuator.metrics
+
+import com.google.inject.AbstractModule
+import com.google.inject.Scopes
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+
+class MetricsModule extends AbstractModule {
+  override def configure(): Unit = {
+    bind(classOf[PrometheusMeterRegistry])
+      .toProvider(classOf[MeterRegistryProvider])
+      .in(Scopes.SINGLETON)
+    bind(classOf[MeterRegistry]).to(classOf[PrometheusMeterRegistry])
+    // Eager so JVM binders register at boot, not on first /metrics scrape.
+    bind(classOf[MeterBindersInitializer]).asEagerSingleton()
+  }
+}

--- a/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MetricsRouter.scala
+++ b/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MetricsRouter.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 Felipe Bonezi <https://about.me/felipebonezi>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package play.actuator.metrics
+
+import javax.inject.Inject
+
+import play.api.routing.Router.Routes
+import play.api.routing.SimpleRouter
+import play.api.routing.sird._
+
+class MetricsRouter @Inject() (controller: MetricsController) extends SimpleRouter {
+  override def routes: Routes = {
+    case GET(p"/")           => controller.list
+    case GET(p"/prometheus") => controller.prometheus
+    case GET(p"/$name")      => controller.detail(name)
+  }
+}

--- a/play-actuator/src/main/resources/reference.conf
+++ b/play-actuator/src/main/resources/reference.conf
@@ -3,9 +3,21 @@ play {
     info.system.enabled = false
     health {
       indicators {
-        diskspace = false
-        database = false
-        redis = false
+        diskSpace = false
+        database  = false
+        redis     = false
+      }
+      # Kubernetes-ready defaults: liveness reports only JVM-local health
+      # (so external-dependency outages don't restart pods), readiness
+      # reports everything else (so the pod is taken out of rotation until
+      # its deps recover). Override or add custom groups in application.conf.
+      groups {
+        liveness {
+          include = ["diskSpace"]
+        }
+        readiness {
+          exclude = ["diskSpace"]
+        }
       }
     }
   }

--- a/play-actuator/src/main/scala/play/actuator/ActuatorController.scala
+++ b/play-actuator/src/main/scala/play/actuator/ActuatorController.scala
@@ -35,9 +35,12 @@ import play.api.mvc.AnyContent
 import play.api.mvc.BaseController
 import play.api.mvc.ControllerComponents
 
-class ActuatorController @Inject() (healthService: HealthService, infoService: InfoService, cc: ControllerComponents)(
-    implicit ec: ExecutionContext
-) extends BaseController {
+class ActuatorController @Inject() (
+    healthService: HealthService,
+    infoService: InfoService,
+    cc: ControllerComponents
+)(implicit ec: ExecutionContext)
+    extends BaseController {
 
   def health: Action[AnyContent] = Action {
     respondHealth(group = None)
@@ -63,10 +66,17 @@ class ActuatorController @Inject() (healthService: HealthService, infoService: I
     val indicators = this.healthService.getIndicators(group)
     val status     = this.healthService.globalStatus(group)
     val body: JsObject =
-      if (indicators.nonEmpty) Json.obj("status" -> status, "indicators" -> toJson(indicators))
-      else Json.obj("status"                     -> status)
+      if (indicators.nonEmpty) {
+        Json.obj("status" -> status, "indicators" -> toJson(indicators))
+      } else {
+        Json.obj("status" -> status)
+      }
     // 503 on aggregated Down lets k8s probes treat the response as a hard failure.
-    if (status == Down) ServiceUnavailable(body) else Ok(body)
+    if (status == Down) {
+      ServiceUnavailable(body)
+    } else {
+      Ok(body)
+    }
   }
 
 }

--- a/play-actuator/src/main/scala/play/actuator/ActuatorController.scala
+++ b/play-actuator/src/main/scala/play/actuator/ActuatorController.scala
@@ -20,36 +20,36 @@
  */
 package play.actuator
 
+import javax.inject.Inject
+
+import scala.concurrent.ExecutionContext
+
+import play.actuator.ActuatorEnum.Down
+import play.actuator.health.HealthService
+import play.actuator.info.InfoService
+import play.api.libs.json.JsObject
 import play.api.libs.json.Json
+import play.api.libs.json.Json.toJson
 import play.api.mvc.Action
 import play.api.mvc.AnyContent
 import play.api.mvc.BaseController
 import play.api.mvc.ControllerComponents
-import play.actuator.ActuatorEnum.Down
-import play.actuator.ActuatorEnum.Status
-import play.actuator.ActuatorEnum.Up
-import play.actuator.health.HealthService
-import play.actuator.info.InfoService
-import play.api.libs.json.Json.toJson
-
-import javax.inject.Inject
-import scala.concurrent.ExecutionContext
 
 class ActuatorController @Inject() (healthService: HealthService, infoService: InfoService, cc: ControllerComponents)(
     implicit ec: ExecutionContext
 ) extends BaseController {
 
   def health: Action[AnyContent] = Action {
-    val indicators = this.healthService.getIndicators
-    if (indicators.nonEmpty) {
-      val status = if (indicators.exists(indicator => indicator.status == Down)) {
-        Down
-      } else {
-        Up
-      }
-      Ok(Json.obj("status" -> status, "indicators" -> toJson(indicators)))
+    respondHealth(group = None)
+  }
+
+  // GET /health/:group — Spring-compatible `liveness`/`readiness` (or any user-defined group).
+  // Unknown group → 404 so k8s probes fail loudly on misconfiguration.
+  def healthGroup(group: String): Action[AnyContent] = Action {
+    if (this.healthService.knowsGroup(group)) {
+      respondHealth(group = Some(group))
     } else {
-      Ok(Json.obj("status" -> this.healthService.globalStatus))
+      NotFound(Json.obj("error" -> s"unknown health group: $group"))
     }
   }
 
@@ -58,5 +58,15 @@ class ActuatorController @Inject() (healthService: HealthService, infoService: I
   }
 
   protected override def controllerComponents: ControllerComponents = this.cc
+
+  private def respondHealth(group: Option[String]) = {
+    val indicators = this.healthService.getIndicators(group)
+    val status     = this.healthService.globalStatus(group)
+    val body: JsObject =
+      if (indicators.nonEmpty) Json.obj("status" -> status, "indicators" -> toJson(indicators))
+      else Json.obj("status"                     -> status)
+    // 503 on aggregated Down lets k8s probes treat the response as a hard failure.
+    if (status == Down) ServiceUnavailable(body) else Ok(body)
+  }
 
 }

--- a/play-actuator/src/main/scala/play/actuator/health/HealthService.scala
+++ b/play-actuator/src/main/scala/play/actuator/health/HealthService.scala
@@ -19,22 +19,23 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package play.actuator.health
-import play.actuator.ActuatorEnum.Status
-import play.actuator.ActuatorEnum.Up
-import play.actuator.ActuatorEnum.Down
-import play.actuator.health.indicator.DiskSpaceIndicator
-import play.actuator.health.indicator.HealthIndicator
-import play.api.Configuration
-
 import javax.annotation.Nullable
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
+
 import scala.collection.mutable
+
+import play.actuator.ActuatorEnum.Down
+import play.actuator.ActuatorEnum.Status
+import play.actuator.ActuatorEnum.Up
+import play.actuator.health.indicator.HealthIndicator
+import play.api.Configuration
 
 @Singleton
 class HealthService @Inject() (
     config: Configuration,
+    groupsConfig: HealthGroupsConfig,
     @Nullable @Named("diskSpaceIndicator")
     diskSpaceIndicator: HealthIndicator,
     @Nullable @Named("databaseIndicator")
@@ -43,28 +44,32 @@ class HealthService @Inject() (
     redisIndicator: HealthIndicator
 ) {
 
-  def globalStatus: Status =
-    if (getIndicators.exists(h => h.status == Down)) {
-      Down
-    } else {
-      Up
+  def globalStatus: Status = globalStatus(None)
+  def globalStatus(group: Option[String]): Status =
+    if (getIndicators(group).exists(_.status == Down)) Down else Up
+
+  def getIndicators: Seq[Health] = getIndicators(None)
+  def getIndicators(group: Option[String]): Seq[Health] = {
+    val filter: String => Boolean = group match {
+      case Some(name) => groupsConfig.get(name).map(g => (n: String) => g.matches(n)).getOrElse(_ => false)
+      case None       => _ => true
     }
 
-  def getIndicators: Seq[Health] = {
     val indicators = mutable.Buffer[Health]()
-    if (isIndicatorActive("diskSpace")) {
+
+    if (isIndicatorActive("diskSpace") && filter("diskSpace")) {
       val builder = new HealthBuilder("diskSpace")
       this.diskSpaceIndicator.info(builder)
       indicators.append(builder.build)
     }
 
-    if (isIndicatorActive("database") && databaseIndicator != null) {
+    if (isIndicatorActive("database") && databaseIndicator != null && filter("database")) {
       val builder = new HealthBuilder("database")
       this.databaseIndicator.info(builder)
       indicators.append(builder.build)
     }
 
-    if (isIndicatorActive("redis") && redisIndicator != null) {
+    if (isIndicatorActive("redis") && redisIndicator != null && filter("redis")) {
       val builder = new HealthBuilder("redis")
       this.redisIndicator.info(builder)
       indicators.append(builder.build)
@@ -72,6 +77,8 @@ class HealthService @Inject() (
 
     indicators.toSeq
   }
+
+  def knowsGroup(name: String): Boolean = groupsConfig.get(name).isDefined
 
   private def isIndicatorActive(name: String): Boolean =
     this.config

--- a/play-actuator/src/main/scala/play/actuator/health/HealthService.scala
+++ b/play-actuator/src/main/scala/play/actuator/health/HealthService.scala
@@ -24,8 +24,6 @@ import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
 
-import scala.collection.mutable
-
 import play.actuator.ActuatorEnum.Down
 import play.actuator.ActuatorEnum.Status
 import play.actuator.ActuatorEnum.Up
@@ -50,35 +48,32 @@ class HealthService @Inject() (
 
   def getIndicators: Seq[Health] = getIndicators(None)
   def getIndicators(group: Option[String]): Seq[Health] = {
-    val filter: String => Boolean = group match {
-      case Some(name) => groupsConfig.get(name).map(g => (n: String) => g.matches(n)).getOrElse(_ => false)
-      case None       => _ => true
-    }
-
-    val indicators = mutable.Buffer[Health]()
-
-    if (isIndicatorActive("diskSpace") && filter("diskSpace")) {
-      val builder = new HealthBuilder("diskSpace")
-      this.diskSpaceIndicator.info(builder)
-      indicators.append(builder.build)
-    }
-
-    if (isIndicatorActive("database") && databaseIndicator != null && filter("database")) {
-      val builder = new HealthBuilder("database")
-      this.databaseIndicator.info(builder)
-      indicators.append(builder.build)
-    }
-
-    if (isIndicatorActive("redis") && redisIndicator != null && filter("redis")) {
-      val builder = new HealthBuilder("redis")
-      this.redisIndicator.info(builder)
-      indicators.append(builder.build)
-    }
-
-    indicators.toSeq
+    val filter = makeFilter(group)
+    val sources = Seq(
+      ("diskSpace", diskSpaceIndicator),
+      ("database", databaseIndicator),
+      ("redis", redisIndicator)
+    )
+    sources.iterator
+      .filter { case (name, ind) => ind != null && isIndicatorActive(name) && filter(name) }
+      .map { case (name, ind) =>
+        val builder = new HealthBuilder(name)
+        ind.info(builder)
+        builder.build
+      }
+      .toSeq
   }
 
   def knowsGroup(name: String): Boolean = groupsConfig.get(name).isDefined
+
+  private def makeFilter(group: Option[String]): String => Boolean = group match {
+    case Some(name) =>
+      groupsConfig.get(name) match {
+        case Some(g) => (n: String) => g.matches(n)
+        case None    => _ => false
+      }
+    case None => _ => true
+  }
 
   private def isIndicatorActive(name: String): Boolean =
     this.config

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -36,6 +36,7 @@ object Common extends AutoPlugin {
   val jdbcIndicatorName  = "play-actuator-jdbc-indicator"
   val slickIndicatorName = "play-actuator-slick-indicator"
   val redisIndicatorName = "play-actuator-redis-indicator"
+  val metricsName        = "play-actuator-metrics"
 
   override def globalSettings: Seq[Setting[_]] =
     Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -86,4 +86,10 @@ object Dependencies {
     playRedisGroup %% "play-redis" % playRedisVersion
   )
 
+  // Micrometer is a pure-JVM library — same artifact serves both Play axes.
+  val metrics = libraryDependencies ++= core ++ Seq(
+    "io.micrometer" % "micrometer-core"                % "1.15.0",
+    "io.micrometer" % "micrometer-registry-prometheus" % "1.15.0",
+  )
+
 }


### PR DESCRIPTION
Spring Boot Actuator-style health groups let operators ask the actuator
for a filtered subset of indicators, which is what Kubernetes liveness
and readiness probes need: liveness should not flap on external-
dependency outages, readiness should.

- HealthGroup / HealthGroupsConfig in core. Groups parse from
  `play.actuator.health.groups.<name>.{include,exclude}` and are
  matched against the indicator names exposed by HealthService.
- HealthService.getIndicators / globalStatus take an optional group.
  Empty include = all; exclude always subtracts.
- ActuatorController.healthGroup(name) handles GET /health/:group;
  unknown group → 404 so misconfigured k8s probes fail loudly.
- /health and /health/:group now return HTTP 503 when the aggregated
  status is Down (Spring parity). Existing 200-only callers should
  treat the new status code as an alert signal.
- reference.conf ships two opinionated default groups: liveness (just
  diskSpace) and readiness (everything except diskSpace). Override or
  extend in application.conf.
- Drive-by fix: reference.conf had a stale `diskspace` (lowercase) key
  that never matched the camelCase the code reads — corrected to
  `diskSpace` to align with HealthService.isIndicatorActive.