### PR TITLE
Polish: developer POM email + scalafmt on metrics module

### DIFF
--- a/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MeterRegistryProvider.scala
+++ b/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MeterRegistryProvider.scala
@@ -32,8 +32,7 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import play.api.Configuration
 
 @Singleton
-class MeterRegistryProvider @Inject() (config: Configuration)
-    extends Provider[PrometheusMeterRegistry] {
+class MeterRegistryProvider @Inject() (config: Configuration) extends Provider[PrometheusMeterRegistry] {
   override def get(): PrometheusMeterRegistry = {
     val registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
     val tags     = commonTags(config)
@@ -48,9 +47,15 @@ class MeterRegistryProvider @Inject() (config: Configuration)
     if (!c.has(key)) {
       Seq.empty
     } else {
-      c.underlying.getObject(key).entrySet().asScala.iterator.map { e =>
-        Tag.of(e.getKey, e.getValue.unwrapped().toString)
-      }.toSeq
+      c.underlying
+        .getObject(key)
+        .entrySet()
+        .asScala
+        .iterator
+        .map { e =>
+          Tag.of(e.getKey, e.getValue.unwrapped().toString)
+        }
+        .toSeq
     }
   }
 }

--- a/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MetricsController.scala
+++ b/play-actuator-indicators/metrics/src/main/scala/play/actuator/metrics/MetricsController.scala
@@ -81,9 +81,9 @@ class MetricsController @Inject() (
       .toSeq
     val baseUnit = Option(meters.head.getId.getBaseUnit).map(JsString.apply)
     val base = Json.obj(
-      "name"            -> name,
-      "measurements"    -> measurements,
-      "availableTags"   -> tags
+      "name"          -> name,
+      "measurements"  -> measurements,
+      "availableTags" -> tags
     )
     baseUnit.fold(base)(u => base + ("baseUnit" -> u))
   }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -60,8 +60,8 @@ object Common extends AutoPlugin {
       developers += Developer(
         "contributors",
         "Contributors",
-        s"https://github.com/felipebonezi/$repoName/graphs/contributors",
-        url("https://github.com/felipebonezi")
+        "",
+        url(s"https://github.com/felipebonezi/$repoName/graphs/contributors")
       ),
     )
 


### PR DESCRIPTION
## Summary

Two cleanups that didn't make it into #68:

### POM polish: `Developer` email field was holding a URL
`project/Common.scala` was passing a contributors-page URL into the `Developer(id, name, email, url)` `email` slot. Sonatype publishes it anyway (no email-format validation), but the resulting POMs displayed a URL where Maven Central expects an email address. Moved the URL to the `url` slot and left email empty.

### Scalafmt: second pass on the metrics module
Re-run of `sbt scalafmtAll` surfaced two minor wrap/indent tweaks on `MetricsController.scala` and `MeterRegistryProvider.scala` that the prior round missed. Pure formatting — no behavior change.

## Verification

| Gate | Outcome |
|---|---|
| `sbt validateCode` (Play 2.9 / Scala 2.13) | green |
| `sbt -Dplay.version=3.0 validateCode` | green |
| `sbt compile` | green |

## Test plan

- [ ] CI matrix green
- [ ] Both `Validate Code` jobs green

After merge, tag `v0.3.0` to fire the publish workflow and ship to Maven Central.